### PR TITLE
add archunit support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,9 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!--    integration test dependencies versions    -->
+        <archunit-junit5.version>1.0.1</archunit-junit5.version>
     </properties>
 
     <dependencies>
@@ -29,9 +32,17 @@
         </dependency>
 
         <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <version>${archunit-junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.23.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/integration-test/java/org/housecallpro/test/ArchitectureTest.java
+++ b/src/integration-test/java/org/housecallpro/test/ArchitectureTest.java
@@ -1,0 +1,23 @@
+package org.housecallpro.test;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.core.domain.properties.CanBeAnnotated.Predicates.annotatedWith;
+import static com.tngtech.archunit.lang.conditions.ArchPredicates.have;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+@AnalyzeClasses(packages = "org.housecallpro.test")
+public class ArchitectureTest {
+
+    @ArchTest
+    public static final ArchRule rule = classes()
+            .that()
+            .containAnyMethodsThat(have(annotatedWith(Test.class)))
+            .should()
+            .haveNameMatching(".*IntegrationTest")
+            .because("It's required to run integration tests in the correct maven build phase");
+
+}


### PR DESCRIPTION
It's good when there is some kind of automated verification of some general architecture rules in projects where more than one person.
https://www.archunit.org/

If the test suite doesn't follow the supported test name pattern the test will fail as in the example below.
<img width="2449" alt="image" src="https://user-images.githubusercontent.com/89909315/231889947-2e28a56c-4f49-4916-a811-e06a1ebb3a82.png">
