### PR TITLE
test(): [JIRA-4] web driver manager and selenium

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <lombok.version>1.18.26</lombok.version>
+
         <!--    integration test dependencies versions    -->
         <archunit-junit5.version>1.0.1</archunit-junit5.version>
         <sel4j-logger.version>2.0.7</sel4j-logger.version>
@@ -21,6 +23,13 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
 
         <!--    integration test dependencies versions    -->
         <archunit-junit5.version>1.0.1</archunit-junit5.version>
+        <web-driver-manager.version>5.3.2</web-driver-manager.version>
+        <selenium.version>4.8.3</selenium.version>
     </properties>
 
     <dependencies>
@@ -42,6 +44,20 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.23.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>${web-driver-manager.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>${selenium.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/integration-test/java/org/housecallpro/browser/BrowserType.java
+++ b/src/integration-test/java/org/housecallpro/browser/BrowserType.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 public enum BrowserType {
     CHROME,
+    CHROME_HEADLESS,
     CHROME_DOCKER,
     SAFARI;
 

--- a/src/integration-test/java/org/housecallpro/browser/BrowserType.java
+++ b/src/integration-test/java/org/housecallpro/browser/BrowserType.java
@@ -1,0 +1,6 @@
+package org.housecallpro.browser;
+
+public enum BrowserType {
+    CHROME,
+    FIREFOX
+}

--- a/src/integration-test/java/org/housecallpro/browser/BrowserType.java
+++ b/src/integration-test/java/org/housecallpro/browser/BrowserType.java
@@ -1,6 +1,22 @@
 package org.housecallpro.browser;
 
+import java.util.Arrays;
+
 public enum BrowserType {
     CHROME,
-    FIREFOX
+    CHROME_DOCKER,
+    SAFARI;
+
+    public static BrowserType getBrowser(String name) {
+        try {
+            return valueOf(name.toUpperCase());
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException(
+                    String.format("[%s] browser is not supported. Please use one of [%s]",
+                            name,
+                            Arrays.stream(values()).map(Enum::toString).toList())
+            );
+        }
+    }
+
 }

--- a/src/integration-test/java/org/housecallpro/browser/BrowserType.java
+++ b/src/integration-test/java/org/housecallpro/browser/BrowserType.java
@@ -4,9 +4,7 @@ import java.util.Arrays;
 
 public enum BrowserType {
     CHROME,
-    CHROME_HEADLESS,
-    CHROME_DOCKER,
-    SAFARI;
+    CHROME_HEADLESS;
 
     public static BrowserType getBrowser(String name) {
         try {

--- a/src/integration-test/java/org/housecallpro/browser/BrowserType.java
+++ b/src/integration-test/java/org/housecallpro/browser/BrowserType.java
@@ -15,8 +15,7 @@ public enum BrowserType {
             throw new IllegalArgumentException(
                     String.format("[%s] browser is not supported. Please use one of [%s]",
                             name,
-                            Arrays.stream(values()).map(Enum::toString).toList())
-            );
+                            Arrays.stream(values()).map(Enum::toString).toList()));
         }
     }
 

--- a/src/integration-test/java/org/housecallpro/browser/DriverFactory.java
+++ b/src/integration-test/java/org/housecallpro/browser/DriverFactory.java
@@ -1,5 +1,0 @@
-package org.housecallpro.browser;
-
-public class DriverFactory {
-
-}

--- a/src/integration-test/java/org/housecallpro/browser/DriverFactory.java
+++ b/src/integration-test/java/org/housecallpro/browser/DriverFactory.java
@@ -1,4 +1,5 @@
 package org.housecallpro.browser;
 
 public class DriverFactory {
+
 }

--- a/src/integration-test/java/org/housecallpro/resource/BrowserConfig.java
+++ b/src/integration-test/java/org/housecallpro/resource/BrowserConfig.java
@@ -1,0 +1,31 @@
+package org.housecallpro.resource;
+
+import lombok.Builder.Default;
+import lombok.Getter;
+import org.housecallpro.browser.BrowserType;
+
+import static org.housecallpro.browser.BrowserType.CHROME;
+
+@Getter
+public class BrowserConfig {
+
+    private static BrowserConfig config;
+
+    @Default
+    private BrowserType browser = CHROME;
+
+
+    private BrowserConfig() {
+        browser = System.getenv("BROWSER") != null
+                ? BrowserType.getBrowser(System.getenv("BROWSER"))
+                : browser;
+    }
+
+    public synchronized static BrowserConfig getConfig() {
+        if (config == null) {
+            config = new BrowserConfig();
+        }
+        return config;
+    }
+
+}

--- a/src/integration-test/java/org/housecallpro/resource/Configuration.java
+++ b/src/integration-test/java/org/housecallpro/resource/Configuration.java
@@ -1,0 +1,24 @@
+package org.housecallpro.resource;
+
+public class Configuration {
+
+    private static Configuration config;
+
+    private final BrowserConfig browserConfig;
+
+    private Configuration() {
+        browserConfig = BrowserConfig.getConfig();
+    }
+
+    public synchronized static Configuration getConfig() {
+        if (config == null) {
+            config = new Configuration();
+        }
+        return config;
+    }
+
+    public static BrowserConfig getBrowserConfig() {
+        return getConfig().browserConfig;
+    }
+
+}

--- a/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
@@ -28,12 +28,12 @@ public abstract class BaseIntegrationTest implements PageInitializer {
     void setupBrowser() {
         BrowserType browser = Configuration.getBrowserConfig().getBrowser();
         switch (browser) {
-            case CHROME_DOCKER -> {
-                if (WebDriverManager.isDockerAvailable()) {
-                    WebDriverManager.chromedriver().browserInDocker().setup();
-                    driver = new ChromeDriver();
-                    logger.info("[{}] browser has been opened with success", browser.name());
-                }
+            case CHROME -> {
+                WebDriverManager.chromedriver().setup();
+                ChromeOptions options = new ChromeOptions();
+                options.setPageLoadStrategy(NORMAL);
+                driver = new ChromeDriver(options);
+                logger.info("[{}] browser has been opened with success", browser.name());
             }
             case CHROME_HEADLESS -> {
                 WebDriverManager.chromedriver().setup();
@@ -43,18 +43,20 @@ public abstract class BaseIntegrationTest implements PageInitializer {
                 driver = new ChromeDriver(options);
                 logger.info("[{}] browser has been opened with success", browser.name());
             }
+            case CHROME_DOCKER -> {
+                if (WebDriverManager.isDockerAvailable()) {
+                    WebDriverManager.chromedriver().browserInDocker().setup();
+                    driver = new ChromeDriver();
+                    logger.info("[{}] browser has been opened with success", browser.name());
+                }
+            }
             case SAFARI -> {
                 WebDriverManager.safaridriver().setup();
                 driver = new SafariDriver();
                 logger.info("[{}] browser has been opened with success", browser.name());
             }
-            default -> {
-                WebDriverManager.chromedriver().setup();
-                ChromeOptions options = new ChromeOptions();
-                options.setPageLoadStrategy(NORMAL);
-                driver = new ChromeDriver(options);
-                logger.info("[{}] browser has been opened with success", browser.name());
-            }
+            default -> throw new IllegalArgumentException(
+                    String.format("Configuration for [%s] browser has not been created", browser));
         }
 
     }

--- a/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
@@ -38,8 +38,6 @@ public abstract class BaseIntegrationTest implements PageInitializer {
                 options.addArguments("--remote-allow-origins=*");
 
                 driver = new ChromeDriver(options);
-                driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
-                driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(60));
                 driver.manage().window().maximize();
 
                 logger.info("[{}] browser has been opened with success", browser.name());

--- a/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
@@ -52,18 +52,6 @@ public abstract class BaseIntegrationTest implements PageInitializer {
                 driver = new ChromeDriver(options);
                 logger.info("[{}] browser has been opened with success", browser.name());
             }
-            case CHROME_DOCKER -> {
-                if (WebDriverManager.isDockerAvailable()) {
-                    WebDriverManager.chromedriver().browserInDocker().setup();
-                    driver = new ChromeDriver();
-                    logger.info("[{}] browser has been opened with success", browser.name());
-                }
-            }
-            case SAFARI -> {
-                WebDriverManager.safaridriver().setup();
-                driver = new SafariDriver();
-                logger.info("[{}] browser has been opened with success", browser.name());
-            }
             default -> throw new IllegalArgumentException(
                     String.format("Configuration for [%s] browser has not been created", browser));
         }

--- a/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
@@ -1,12 +1,15 @@
 package org.housecallpro.test;
 
 import io.github.bonigarcia.wdm.WebDriverManager;
+import org.housecallpro.browser.BrowserType;
 import org.housecallpro.page.PageInitializer;
+import org.housecallpro.resource.Configuration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.safari.SafariDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,9 +24,27 @@ public abstract class BaseIntegrationTest implements PageInitializer {
 
     @BeforeAll
     void setupBrowser() {
-        WebDriverManager.chromedriver().setup();
-        driver = new ChromeDriver();
-        logger.info("[%s] browser has been opened with success");
+        BrowserType browser = Configuration.getBrowserConfig().getBrowser();
+        switch (browser) {
+            case CHROME_DOCKER -> {
+                if (WebDriverManager.isDockerAvailable()) {
+                    WebDriverManager.chromedriver().browserInDocker().setup();
+                    driver = new ChromeDriver();
+                    logger.info("[{}] browser has been opened with success", browser.name());
+                }
+            }
+            case SAFARI -> {
+                WebDriverManager.safaridriver().setup();
+                driver = new SafariDriver();
+                logger.info("[{}] browser has been opened with success", browser.name());
+            }
+            default -> {
+                WebDriverManager.chromedriver().setup();
+                driver = new ChromeDriver();
+                logger.info("[{}] browser has been opened with success", browser.name());
+            }
+        }
+
     }
 
     @AfterEach

--- a/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
@@ -14,6 +14,8 @@ import org.openqa.selenium.safari.SafariDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Duration;
+
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.openqa.selenium.PageLoadStrategy.NORMAL;
 
@@ -30,9 +32,16 @@ public abstract class BaseIntegrationTest implements PageInitializer {
         switch (browser) {
             case CHROME -> {
                 WebDriverManager.chromedriver().setup();
+
                 ChromeOptions options = new ChromeOptions();
                 options.setPageLoadStrategy(NORMAL);
+                options.addArguments("--remote-allow-origins=*");
+
                 driver = new ChromeDriver(options);
+                driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
+                driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(60));
+                driver.manage().window().maximize();
+
                 logger.info("[{}] browser has been opened with success", browser.name());
             }
             case CHROME_HEADLESS -> {

--- a/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
@@ -1,13 +1,33 @@
 package org.housecallpro.test;
 
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.housecallpro.page.PageInitializer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
 
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
 public abstract class BaseIntegrationTest implements PageInitializer {
 
-    @BeforeAll
-    static void setupBrowser() {
+    WebDriver driver;
 
+    @BeforeAll
+    void setupBrowser() {
+        WebDriverManager.chromedriver().setup();
+        driver = new ChromeDriver();
+    }
+
+    @AfterEach
+    void closeBrowser() {
+        driver.quit();
+    }
+
+    protected void openApplication() {
+        driver.get("https://pro.housecallpro.com/pro/log_in");
     }
 
 }

--- a/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
@@ -7,11 +7,15 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 
 @TestInstance(PER_CLASS)
 public abstract class BaseIntegrationTest implements PageInitializer {
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseIntegrationTest.class);
 
     WebDriver driver;
 
@@ -19,11 +23,13 @@ public abstract class BaseIntegrationTest implements PageInitializer {
     void setupBrowser() {
         WebDriverManager.chromedriver().setup();
         driver = new ChromeDriver();
+        logger.info("[%s] browser has been opened with success");
     }
 
     @AfterEach
     void closeBrowser() {
         driver.quit();
+        logger.info("browser has been closed with success");
     }
 
     protected void openApplication() {

--- a/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
@@ -9,11 +9,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.safari.SafariDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.openqa.selenium.PageLoadStrategy.NORMAL;
 
 @TestInstance(PER_CLASS)
 public abstract class BaseIntegrationTest implements PageInitializer {
@@ -33,6 +35,14 @@ public abstract class BaseIntegrationTest implements PageInitializer {
                     logger.info("[{}] browser has been opened with success", browser.name());
                 }
             }
+            case CHROME_HEADLESS -> {
+                WebDriverManager.chromedriver().setup();
+                ChromeOptions options = new ChromeOptions();
+                options.setPageLoadStrategy(NORMAL);
+                options.addArguments("--headless=new");
+                driver = new ChromeDriver(options);
+                logger.info("[{}] browser has been opened with success", browser.name());
+            }
             case SAFARI -> {
                 WebDriverManager.safaridriver().setup();
                 driver = new SafariDriver();
@@ -40,7 +50,9 @@ public abstract class BaseIntegrationTest implements PageInitializer {
             }
             default -> {
                 WebDriverManager.chromedriver().setup();
-                driver = new ChromeDriver();
+                ChromeOptions options = new ChromeOptions();
+                options.setPageLoadStrategy(NORMAL);
+                driver = new ChromeDriver(options);
                 logger.info("[{}] browser has been opened with success", browser.name());
             }
         }

--- a/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/BaseIntegrationTest.java
@@ -10,11 +10,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.safari.SafariDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.time.Duration;
 
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.openqa.selenium.PageLoadStrategy.NORMAL;
@@ -44,10 +41,14 @@ public abstract class BaseIntegrationTest implements PageInitializer {
             }
             case CHROME_HEADLESS -> {
                 WebDriverManager.chromedriver().setup();
+
                 ChromeOptions options = new ChromeOptions();
                 options.setPageLoadStrategy(NORMAL);
                 options.addArguments("--headless=new");
+
                 driver = new ChromeDriver(options);
+                driver.manage().window().maximize();
+
                 logger.info("[{}] browser has been opened with success", browser.name());
             }
             default -> throw new IllegalArgumentException(

--- a/src/integration-test/java/org/housecallpro/test/ExampleIntegrationTest.java
+++ b/src/integration-test/java/org/housecallpro/test/ExampleIntegrationTest.java
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test;
 public class ExampleIntegrationTest extends BaseIntegrationTest {
 
     @Test
-    void shouldCreateNewJob() {
-
+    void shouldOpenApplication() {
+        openApplication();
     }
 
 }

--- a/src/integration-test/java/org/housecallpro/test/architecture/ArchitectureTest.java
+++ b/src/integration-test/java/org/housecallpro/test/architecture/ArchitectureTest.java
@@ -1,4 +1,4 @@
-package org.housecallpro.test;
+package org.housecallpro.test.architecture;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;


### PR DESCRIPTION
In scope of this PR I've added:
- [WebDriverManager](https://bonigarcia.dev/webdrivermanager/) support to manage driver version dynamically on each user machine in case of local development.
- Resource manager - to manage configurations - might be useful in CI/CD pipeline executions can be combined with [helm charts](https://helm.sh/docs/topics/charts/).
- Added support for chrome browser with and without headless mode - structure which can be easily extended.

By default chrome without headless mode should be opened.
If we want to run a test in headless mode a BROWSER env variable needs to be set.
For local development purposes it can be set as in the example pictures below (for IntelliJ IDE users).
<img width="637" alt="image" src="https://user-images.githubusercontent.com/89909315/232129127-bda7d71c-3fbd-49d6-88dd-4d8478c3d12f.png">
<img width="646" alt="image" src="https://user-images.githubusercontent.com/89909315/232129388-98e7b9a4-7fc0-471a-bb5c-d33826f7fa4e.png">

Additional info about settings:
NORMAL - https://www.selenium.dev/documentation/webdriver/drivers/options/
headless=new - https://www.selenium.dev/blog/2023/headless-is-going-away/